### PR TITLE
Habilitação de parâmetro de data de vencimento para o boleto

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    moip (1.0.1)
+    moip (1.0.2)
       activesupport (>= 2.3.2)
       httparty (~> 0.6.1)
       nokogiri (~> 1.4.3)
@@ -9,12 +9,16 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.0.8)
+    activesupport (3.2.9)
+      i18n (~> 0.6)
+      multi_json (~> 1.0)
     crack (0.1.8)
     diff-lcs (1.1.2)
     httparty (0.6.1)
       crack (= 0.1.8)
-    nokogiri (1.4.6)
+    i18n (0.6.1)
+    multi_json (1.5.0)
+    nokogiri (1.4.7)
     rspec (2.1.0)
       rspec-core (~> 2.1.0)
       rspec-expectations (~> 2.1.0)

--- a/lib/moip/direct_payment.rb
+++ b/lib/moip/direct_payment.rb
@@ -153,8 +153,12 @@ module MoIP
               if attributes[:forma] == "BoletoBancario"
                 # Dados extras
                 xml.Boleto {
+
                   xml.DiasExpiracao(:Tipo => "Corridos") {
                     xml.text attributes[:dias_expiracao]
+                  }
+                  xml.DataVencimento {
+                    xml.text attributes[:data_vencimento]
                   }
                   xml.Instrucao1 {
                     xml.text attributes[:instrucao_1]


### PR DESCRIPTION
Houve a necessidade de especificar data de vencimento de um boleto, para que seja gerado boletos em lote com datas certas.
